### PR TITLE
Read patRoon featureID format & quiet verbose outputs

### DIFF
--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -153,62 +153,64 @@ FingerPrintTable <- function(subfolder, fp_names_pos, fp_names_neg, fp_names_com
 
 #' @export
 FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
+  
   fingerprint_data <- tibble()
 
   if (length(subfolder) > 0 ){
-  # progress bar
-  ii = 1
-  print("Reading in positive mode SIRIUS files ...")
-  pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0, style = 3)
+    # progress bar
+    ii = 1
+    print("Reading in positive mode SIRIUS files ...")
+    pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0, style = 3)
 
-  for(direct in subfolder){
-# subfolder with data must be on a form where id is on second place after nr_ (0_Einc270001_Einc270001)
-    file_name <- str_split(direct, "_")
-    comp_name <- str_split(direct, "/")
+    for(direct in subfolder){
+      # subfolder with data must be on a form where id is on second place after nr_ (0_Einc270001_Einc270001)
+      file_name <- str_split(direct, "_")
+      comp_name <- str_split(direct, "/")
 
-    sir_fold <- file_name[[1]][1]
+      sir_fold <- file_name[[1]][1]
 
-    # detect patRoon featureID and parse to output
-    if (str_detect(file_name[[1]][2], "M") & str_detect(file_name[[1]][3], "R")) {
-      id_this <- str_c(file_name[[1]][2], file_name[[1]][3], file_name[[1]][4], sep = "_")
-    } else id_this <- file_name[[1]][2]
+      # detect patRoon featureID and parse to output
+      if (str_detect(file_name[[1]][2], "M") & str_detect(file_name[[1]][3], "R")) {
+        id_this <- str_c(file_name[[1]][2], file_name[[1]][3], file_name[[1]][4], sep = "_")
+      } else id_this <- file_name[[1]][2]
     
-    pred_ion <- comp_name[[1]][3]
-    # changed from readr::read_delim to utils::read.delim due to verbose output
-    filedata <- read.delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), sep = " ", header = FALSE)
-    filedata <- as_tibble(t(filedata))
-    filedata <- filedata %>%
-      mutate(predion = pred_ion) %>%
-      mutate(predion = sub("\\..*", "", predion)) %>%
-      mutate(id = id_this) %>%
-      mutate(sir_fol_nr = sir_fold) %>%
-      mutate(predform = sub("\\_.*", "", predion))
-    fingerprint_data <- fingerprint_data %>%
-      bind_rows(filedata)
+      pred_ion <- comp_name[[1]][3]
+      # changed from readr::read_delim to utils::read.delim due to verbose output
+      filedata <- read.delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), sep = " ", header = FALSE)
+      filedata <- as_tibble(t(filedata))
+      filedata <- filedata %>%
+        mutate(predion = pred_ion) %>%
+        mutate(predion = sub("\\..*", "", predion)) %>%
+        mutate(id = id_this) %>%
+        mutate(sir_fol_nr = sir_fold) %>%
+       mutate(predform = sub("\\_.*", "", predion))
+      fingerprint_data <- fingerprint_data %>%
+        bind_rows(filedata)
 
-    # update progress bar
-    setTxtProgressBar(pb, ii)
-    ii = ii + 1
+      # update progress bar
+      setTxtProgressBar(pb, ii)
+      ii = ii + 1
     
-    }
-  Sys.sleep(1)
-  close(pb)
-  return(fingerprint_data)
-}
+      }
+    Sys.sleep(1)
+    close(pb)
+    return(fingerprint_data)
   } else return fingerprint_data
+}
 
 #' @export
 FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
+  
   fingerprint_data <- tibble()
 
   if (length(subfolder) > 0){
-  # progress bar
-  ii = 1
-  print("Reading in negative mode SIRIUS files ...")
-  pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0, style = 3)
+    # progress bar
+    ii = 1
+    print("Reading in negative mode SIRIUS files ...")
+    pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0, style = 3)
   
-  for(direct in subfolder){
-# subfolder with data must be on a form where id is on second place after nr_ (0_Einc270001_Einc270001)
+    for(direct in subfolder){
+      # subfolder with data must be on a form where id is on second place after nr_ (0_Einc270001_Einc270001)
       file_name <- str_split(direct, "_")
       comp_name <- str_split(direct, "/")
 
@@ -241,8 +243,8 @@ FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
   Sys.sleep(1)
   close(pb)
   return(fingerprint_data)
-}
-  } else return(fingerprint_data)
+} else return(fingerprint_data)
+  }
 
 #' @export
 SiriusScoreRank1 <- function(subfolder_score, folderwithSIRIUSfiles){

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -155,6 +155,11 @@ FingerPrintTable <- function(subfolder, fp_names_pos, fp_names_neg, fp_names_com
 #' @export
 FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
   fingerprint_data <- tibble()
+
+  # options for progress bar
+  options(width = 80)
+  n <- length(subfolder)
+  
   for(direct in subfolder){
 # subfolder with data must be on a form where id is on second place after nr_ (0_Einc270001_Einc270001)
     file_name <- str_split(direct, "_")
@@ -179,7 +184,18 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
       mutate(predform = sub("\\_.*", "", predion))
     fingerprint_data <- fingerprint_data %>%
       bind_rows(filedata)
-  }
+
+    # add progress bar
+    extra <- nchar('||100%')
+    width <- options()$width
+    step <- round(direct / n * (width - extra))
+    text <- sprintf('|%s%s|% 3s%%', strrep('=', step),
+                    strrep(' ', width - step - extra), round(direct / n * 100))
+    cat(text)
+    Sys.sleep(0.05)
+    cat(if (direct == n) '\n' else '\014')
+      
+    }
   return(fingerprint_data)
 }
 

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -68,8 +68,9 @@ FpTableForPredictions <- function(folderwithSIRIUSfiles){
   subfolder <- dir(folderwithSIRIUSfiles, all.files = TRUE, recursive = TRUE, pattern = ".fpt")
   subfolder_score <- dir(folderwithSIRIUSfiles, all.files = TRUE, recursive = TRUE, pattern = ".info")
 
-  fp_names_pos <- paste("Un", read_delim(paste(folderwithSIRIUSfiles,"/csi_fingerid.tsv", sep = ""), delim = "\t", show_col_types = FALSE)$absoluteIndex, sep = "")
-  fp_names_neg <- paste("Un", read_delim(paste(folderwithSIRIUSfiles,"/csi_fingerid_neg.tsv", sep = "" ), delim = "\t", show_col_types = FALSE)$absoluteIndex, sep = "")
+  # changed from readr::read_delim to utils::read.delim due to verbose output
+  fp_names_pos <- paste("Un", read.delim(paste(folderwithSIRIUSfiles,"/csi_fingerid.tsv", sep = ""), sep = "\t")$absoluteIndex, sep = "")
+  fp_names_neg <- paste("Un", read.delim(paste(folderwithSIRIUSfiles,"/csi_fingerid_neg.tsv", sep = "" ), sep = "\t")$absoluteIndex, sep = "")
   fp_names_common <- as.data.frame(fp_names_pos)  %>%
     mutate(fp_names_neg = fp_names_pos) %>%
     inner_join(as.data.frame(fp_names_neg))
@@ -174,8 +175,8 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
     } else id_this <- file_name[[1]][2]
     
     pred_ion <- comp_name[[1]][3]
-
-    filedata <- read_delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), delim = " ", col_names = FALSE, show_col_types = FALSE)
+    # changed from readr::read_delim to utils::read.delim due to verbose output
+    filedata <- read.delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), sep = " ")
     filedata <- as_tibble(t(filedata))
     filedata <- filedata %>%
       mutate(predion = pred_ion) %>%
@@ -218,7 +219,8 @@ FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
     
       pred_ion <- comp_name[[1]][3]
 
-      filedata <- read_delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), delim = " ", col_names = FALSE, show_col_types = FALSE)
+      # changed from readr::read_delim to utils::read.delim due to verbose output
+      filedata <- read.delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), sep = " ")
       filedata <- as_tibble(t(filedata))
       filedata <- filedata %>%
         mutate(predion = pred_ion) %>%
@@ -248,7 +250,12 @@ SiriusScoreRank1 <- function(subfolder_score, folderwithSIRIUSfiles){
       comp_name_score <- str_split(filename, "/")
 
       foldernumber <- file_name_score[[1]][1]
-      id <- file_name_score[[1]][2] #if id is not in second place, [2] must be changed
+      
+      # detect patRoon featureID and parse to output
+      if (str_detect(file_name[[1]][2], "M") & str_detect(file_name[[1]][3], "R")) {
+        id <- str_c(file_name[[1]][2], file_name[[1]][3], file_name[[1]][4], sep = "_")
+      } else id <- file_name[[1]][2]
+      
       pred_st <- comp_name_score[[1]][3]
 
       fileConnection <- file(paste(folderwithSIRIUSfiles, filename, sep = "/"))

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -111,12 +111,12 @@ FingerPrintTable <- function(subfolder, fp_names_pos, fp_names_neg, fp_names_com
     }
   }
 
-  if(!is.null(subfolder_pos){
+  if(!is.null(subfolder_pos)){
     fp_pos <- FingerPrintTablePOS(subfolder_pos, folderwithSIRIUSfiles)
     colnames(fp_pos) <- c(fp_names_pos, "predion", "id", "foldernumber", "predform")
   }
 
-  if(!is.null(subfolder_neg){
+  if(!is.null(subfolder_neg)){
     fp_neg <- FingerPrintTableNEG(subfolder_neg, folderwithSIRIUSfiles)
     colnames(fp_neg) <- c(fp_names_neg, "predion", "id", "foldernumber", "predform")
   }

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -68,8 +68,8 @@ FpTableForPredictions <- function(folderwithSIRIUSfiles){
   subfolder <- dir(folderwithSIRIUSfiles, all.files = TRUE, recursive = TRUE, pattern = ".fpt")
   subfolder_score <- dir(folderwithSIRIUSfiles, all.files = TRUE, recursive = TRUE, pattern = ".info")
 
-  fp_names_pos <- paste("Un", read_delim(paste(folderwithSIRIUSfiles,"/csi_fingerid.tsv", sep = ""), delim = "\t")$absoluteIndex, sep = "")
-  fp_names_neg <- paste("Un", read_delim(paste(folderwithSIRIUSfiles,"/csi_fingerid_neg.tsv", sep = "" ), delim = "\t")$absoluteIndex, sep = "")
+  fp_names_pos <- paste("Un", read_delim(paste(folderwithSIRIUSfiles,"/csi_fingerid.tsv", sep = ""), delim = "\t", show_col_types = FALSE)$absoluteIndex, sep = "")
+  fp_names_neg <- paste("Un", read_delim(paste(folderwithSIRIUSfiles,"/csi_fingerid_neg.tsv", sep = "" ), delim = "\t", show_col_types = FALSE)$absoluteIndex, sep = "")
   fp_names_common <- as.data.frame(fp_names_pos)  %>%
     mutate(fp_names_neg = fp_names_pos) %>%
     inner_join(as.data.frame(fp_names_neg))

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -156,7 +156,11 @@ FingerPrintTable <- function(subfolder, fp_names_pos, fp_names_neg, fp_names_com
 #' @export
 FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
   fingerprint_data <- tibble()
-  
+
+  # progress bar
+  ii = 1
+  pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0)
+
   for(direct in subfolder){
 # subfolder with data must be on a form where id is on second place after nr_ (0_Einc270001_Einc270001)
     file_name <- str_split(direct, "_")
@@ -171,7 +175,7 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
     
     pred_ion <- comp_name[[1]][3]
     # changed from readr::read_delim to utils::read.delim due to verbose output
-    filedata <- read.delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), sep = " ")
+    filedata <- read.delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), sep = " ", header = FALSE)
     filedata <- as_tibble(t(filedata))
     filedata <- filedata %>%
       mutate(predion = pred_ion) %>%
@@ -181,7 +185,14 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
       mutate(predform = sub("\\_.*", "", predion))
     fingerprint_data <- fingerprint_data %>%
       bind_rows(filedata)
+
+    # update progress bar
+    Sys.sleep(0.5); setTxtProgressBar(pb, ii)
+    ii = ii + 1
+    
     }
+  Sys.sleep(1)
+  close(pb)
   return(fingerprint_data)
 }
 
@@ -203,7 +214,7 @@ FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
       pred_ion <- comp_name[[1]][3]
 
       # changed from readr::read_delim to utils::read.delim due to verbose output
-      filedata <- read.delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), sep = " ")
+      filedata <- read.delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), sep = " ", header = FALSE)
       filedata <- as_tibble(t(filedata))
       filedata <- filedata %>%
         mutate(predion = pred_ion) %>%

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -111,15 +111,13 @@ FingerPrintTable <- function(subfolder, fp_names_pos, fp_names_neg, fp_names_com
     }
   }
 
-  fp_pos <- FingerPrintTablePOS(subfolder_pos, folderwithSIRIUSfiles)
-
-  if(nrow(fp_pos) != 0){
+  if(length(subfolder_pos) != 0){
+    fp_pos <- FingerPrintTablePOS(subfolder_pos, folderwithSIRIUSfiles)
     colnames(fp_pos) <- c(fp_names_pos, "predion", "id", "foldernumber", "predform")
   }
 
-  fp_neg <- FingerPrintTableNEG(subfolder_neg, folderwithSIRIUSfiles)
-
-  if(nrow(fp_neg) != 0){
+  if(length(subfolder_neg) != 0){
+    fp_neg <- FingerPrintTableNEG(subfolder_neg, folderwithSIRIUSfiles)
     colnames(fp_neg) <- c(fp_names_neg, "predion", "id", "foldernumber", "predform")
   }
 

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -159,6 +159,7 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
 
   # progress bar
   ii = 1
+  print("Reading in positive mode SIRIUS files ...")
   pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0, style = 3)
 
   for(direct in subfolder){
@@ -199,6 +200,12 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
 #' @export
 FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
   fingerprint_data <- tibble()
+
+  # progress bar
+  ii = 1
+  print("Reading in negative mode SIRIUS files ...")
+  pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0, style = 3)
+  
   for(direct in subfolder){
 # subfolder with data must be on a form where id is on second place after nr_ (0_Einc270001_Einc270001)
       file_name <- str_split(direct, "_")
@@ -224,8 +231,14 @@ FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
         mutate(predform = sub("\\_.*", "", predion))
       fingerprint_data <- fingerprint_data %>%
         bind_rows(filedata)
-
-  }
+    
+    # update progress bar
+    setTxtProgressBar(pb, ii)
+    ii = ii + 1
+    
+    }
+  Sys.sleep(1)
+  close(pb)
   return(fingerprint_data)
 }
 
@@ -246,9 +259,9 @@ SiriusScoreRank1 <- function(subfolder_score, folderwithSIRIUSfiles){
       foldernumber <- file_name_score[[1]][1]
       
       # detect patRoon featureID and parse to output
-      if (str_detect(file_name[[1]][2], "M") & str_detect(file_name[[1]][3], "R")) {
-        id <- str_c(file_name[[1]][2], file_name[[1]][3], file_name[[1]][4], sep = "_")
-      } else id <- file_name[[1]][2]
+      if (str_detect(file_name_score[[1]][2], "M") & str_detect(file_name_score[[1]][3], "R")) {
+        id <- str_c(file_name_score[[1]][2], file_name_score[[1]][3], file_name_score[[1]][4], sep = "_")
+      } else id <- file_name_score[[1]][2]
       
       pred_st <- comp_name_score[[1]][3]
 

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -111,12 +111,12 @@ FingerPrintTable <- function(subfolder, fp_names_pos, fp_names_neg, fp_names_com
     }
   }
 
-  if(length(subfolder_pos) != 0){
+  if(!is.null(subfolder_pos){
     fp_pos <- FingerPrintTablePOS(subfolder_pos, folderwithSIRIUSfiles)
     colnames(fp_pos) <- c(fp_names_pos, "predion", "id", "foldernumber", "predform")
   }
 
-  if(length(subfolder_neg) != 0){
+  if(!is.null(subfolder_neg){
     fp_neg <- FingerPrintTableNEG(subfolder_neg, folderwithSIRIUSfiles)
     colnames(fp_neg) <- c(fp_names_neg, "predion", "id", "foldernumber", "predform")
   }

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -158,7 +158,7 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
 
   if (length(subfolder) > 0){
     # initialise progress bar
-    printf(paste0("Found", length(subfolder), "positive mode SIRIUS files", sep = " "))
+    print(paste0("Found", length(subfolder), "positive mode SIRIUS files", sep = " "))
     ii = 1
     pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0, style = 3)
 
@@ -194,7 +194,7 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
       }
 
     close(pb)
-    printf("Done!")
+    print("Done!")
     return(fingerprint_data)
     
   } else return(fingerprint_data)
@@ -208,7 +208,7 @@ FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
   if (length(subfolder) > 0){
     # progress bar
     ii = 1
-    printf(paste0("Found", length(subfolder), "negative mode SIRIUS files", sep = " "))
+    print(paste0("Found", length(subfolder), "negative mode SIRIUS files", sep = " "))
     pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0, style = 3)
   
     for(direct in subfolder){
@@ -244,7 +244,7 @@ FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
     }
   
   close(pb)
-  printf("Done!")
+  print("Done!")
     return(fingerprint_data)
 } else return(fingerprint_data)
   }

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -161,7 +161,12 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
     comp_name <- str_split(direct, "/")
 
     sir_fold <- file_name[[1]][1]
-    id_this <- file_name[[1]][2] # if id in some other position, this can be changed
+
+    # detect patRoon featureID and parse to output
+    if (str_detect(file_name[[1]][2], "M") & str_detect(file_name[[1]][3], "R")) {
+      id_this <- str_c(file_name[[1]][2], file_name[[1]][3], file_name[[1]][4], sep = "_")
+    } else id_this <- file_name[[1]][2]
+    
     pred_ion <- comp_name[[1]][3]
 
     filedata <- read_delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), delim = " ", col_names = FALSE)
@@ -187,7 +192,12 @@ FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
       comp_name <- str_split(direct, "/")
 
       sir_fold <- file_name[[1]][1]
-      id_this <- file_name[[1]][2]
+    
+      # detect patRoon featureID and parse to output
+      if (str_detect(file_name[[1]][2], "M") & str_detect(file_name[[1]][3], "R")) {
+        id_this <- str_c(file_name[[1]][2], file_name[[1]][3], file_name[[1]][4], sep = "_")
+      } else id_this <- file_name[[1]][2]
+    
       pred_ion <- comp_name[[1]][3]
 
       filedata <- read_delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), delim = " ", col_names = FALSE)

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -159,7 +159,7 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
 
   # progress bar
   ii = 1
-  pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0)
+  pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0, style = 3)
 
   for(direct in subfolder){
 # subfolder with data must be on a form where id is on second place after nr_ (0_Einc270001_Einc270001)
@@ -187,7 +187,7 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
       bind_rows(filedata)
 
     # update progress bar
-    Sys.sleep(0.5); setTxtProgressBar(pb, ii)
+    setTxtProgressBar(pb, ii)
     ii = ii + 1
     
     }

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -158,6 +158,7 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
 
   # options for progress bar
   options(width = 80)
+  ii <- 1
   n <- length(subfolder)
   
   for(direct in subfolder){
@@ -188,12 +189,13 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
     # add progress bar
     extra <- nchar('||100%')
     width <- options()$width
-    step <- round(direct / n * (width - extra))
+    step <- round(ii / n * (width - extra))
     text <- sprintf('|%s%s|% 3s%%', strrep('=', step),
-                    strrep(' ', width - step - extra), round(direct / n * 100))
+                    strrep(' ', width - step - extra), round(ii / n * 100))
     cat(text)
     Sys.sleep(0.05)
-    cat(if (direct == n) '\n' else '\014')
+    cat(if (ii == n) '\n' else '\014')
+    ii = ii + 1
       
     }
   return(fingerprint_data)

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -155,6 +155,7 @@ FingerPrintTable <- function(subfolder, fp_names_pos, fp_names_neg, fp_names_com
 FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
   fingerprint_data <- tibble()
 
+  if (length(subfolder) > 0 ){
   # progress bar
   ii = 1
   print("Reading in positive mode SIRIUS files ...")
@@ -194,11 +195,13 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
   close(pb)
   return(fingerprint_data)
 }
+  } else return fingerprint_data
 
 #' @export
 FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
   fingerprint_data <- tibble()
 
+  if (length(subfolder) > 0){
   # progress bar
   ii = 1
   print("Reading in negative mode SIRIUS files ...")
@@ -239,6 +242,7 @@ FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
   close(pb)
   return(fingerprint_data)
 }
+  } else return(fingerprint_data)
 
 #' @export
 SiriusScoreRank1 <- function(subfolder_score, folderwithSIRIUSfiles){

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -114,12 +114,12 @@ FingerPrintTable <- function(subfolder, fp_names_pos, fp_names_neg, fp_names_com
   if(!is.null(subfolder_pos)){
     fp_pos <- FingerPrintTablePOS(subfolder_pos, folderwithSIRIUSfiles)
     colnames(fp_pos) <- c(fp_names_pos, "predion", "id", "foldernumber", "predform")
-  }
+  } else fp_pos = NULL
 
   if(!is.null(subfolder_neg)){
     fp_neg <- FingerPrintTableNEG(subfolder_neg, folderwithSIRIUSfiles)
     colnames(fp_neg) <- c(fp_names_neg, "predion", "id", "foldernumber", "predform")
-  }
+  } else fp_neg = NULL
 
   if (!is.null(subfolder_neg) & !is.null(subfolder_pos)){
 

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -156,10 +156,10 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
   
   fingerprint_data <- tibble()
 
-  if (length(subfolder) > 0 ){
-    # progress bar
+  if (length(subfolder) > 0){
+    # initialise progress bar
+    printf(paste0("Found", length(subfolder), "positive mode SIRIUS files", sep = " "))
     ii = 1
-    print("Reading in positive mode SIRIUS files ...")
     pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0, style = 3)
 
     for(direct in subfolder){
@@ -192,9 +192,11 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
       ii = ii + 1
     
       }
-    Sys.sleep(1)
+
     close(pb)
+    printf("Done!")
     return(fingerprint_data)
+    
   } else return(fingerprint_data)
 }
 
@@ -206,7 +208,7 @@ FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
   if (length(subfolder) > 0){
     # progress bar
     ii = 1
-    print("Reading in negative mode SIRIUS files ...")
+    printf(paste0("Found", length(subfolder), "negative mode SIRIUS files", sep = " "))
     pb <- txtProgressBar(min = 0, max = length(subfolder), initial = 0, style = 3)
   
     for(direct in subfolder){
@@ -240,9 +242,10 @@ FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
     ii = ii + 1
     
     }
-  Sys.sleep(1)
+  
   close(pb)
-  return(fingerprint_data)
+  printf("Done!")
+    return(fingerprint_data)
 } else return(fingerprint_data)
   }
 

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -195,7 +195,7 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
     Sys.sleep(1)
     close(pb)
     return(fingerprint_data)
-  } else return fingerprint_data
+  } else return(fingerprint_data)
 }
 
 #' @export

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -169,7 +169,7 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
     
     pred_ion <- comp_name[[1]][3]
 
-    filedata <- read_delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), delim = " ", col_names = FALSE)
+    filedata <- read_delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), delim = " ", col_names = FALSE, show_col_types = FALSE)
     filedata <- as_tibble(t(filedata))
     filedata <- filedata %>%
       mutate(predion = pred_ion) %>%
@@ -200,7 +200,7 @@ FingerPrintTableNEG <- function(subfolder, folderwithSIRIUSfiles){
     
       pred_ion <- comp_name[[1]][3]
 
-      filedata <- read_delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), delim = " ", col_names = FALSE)
+      filedata <- read_delim(paste(folderwithSIRIUSfiles, direct, sep = "/"), delim = " ", col_names = FALSE, show_col_types = FALSE)
       filedata <- as_tibble(t(filedata))
       filedata <- filedata %>%
         mutate(predion = pred_ion) %>%

--- a/R/MS2Tox_github.R
+++ b/R/MS2Tox_github.R
@@ -156,11 +156,6 @@ FingerPrintTable <- function(subfolder, fp_names_pos, fp_names_neg, fp_names_com
 #' @export
 FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
   fingerprint_data <- tibble()
-
-  # options for progress bar
-  options(width = 80)
-  ii <- 1
-  n <- length(subfolder)
   
   for(direct in subfolder){
 # subfolder with data must be on a form where id is on second place after nr_ (0_Einc270001_Einc270001)
@@ -186,18 +181,6 @@ FingerPrintTablePOS <- function(subfolder, folderwithSIRIUSfiles){
       mutate(predform = sub("\\_.*", "", predion))
     fingerprint_data <- fingerprint_data %>%
       bind_rows(filedata)
-
-    # add progress bar
-    extra <- nchar('||100%')
-    width <- options()$width
-    step <- round(ii / n * (width - extra))
-    text <- sprintf('|%s%s|% 3s%%', strrep('=', step),
-                    strrep(' ', width - step - extra), round(ii / n * 100))
-    cat(text)
-    Sys.sleep(0.05)
-    cat(if (ii == n) '\n' else '\014')
-    ii = ii + 1
-      
     }
   return(fingerprint_data)
 }


### PR DESCRIPTION
Hey all,

I just made some minor changes to detect featureID in patRoon format (Mxxx_Rxxx_xxx) so that the MS2Tox results keep the full featureID. patRoon featureID are seperated by "_" so it was only selecting the first string to the results.

Also, I made the analysis less verbose, which was mainly the readr::read_delim function. I used the utils::read.delim instead, which should be compatible universally. I added a basic progress bar for this process in both positive and negative. I had to change the order of operations a little bit to get that working properly.

I have tested with the ExampleData provided on the repo, and with my own data processed with patRoon. There are some more warnings that I could see but I think this is regarding some deprecated functions.